### PR TITLE
Give consumers the option to change the path, with default still usin…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,12 @@ WORKDIR /root
 
 # install Prism
 ADD https://raw.githubusercontent.com/stoplightio/prism/master/install install.sh
+RUN apt-get update && apt-get install dos2unix
 RUN chmod +x ./install.sh && sync && \
+    dos2unix ./install.sh && \
     ./install.sh && \
     rm ./install.sh
+
 
 # set up default Twilio SendGrid env
 WORKDIR /root
@@ -18,5 +21,6 @@ WORKDIR /root
 RUN mkdir sendgrid-php
 COPY entrypoint.sh entrypoint.sh
 RUN chmod +x entrypoint.sh
+RUN dos2unix ./entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]
 CMD ["--mock"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV SENDGRID_API_KEY $SENDGRID_API_KEY
 WORKDIR /root
 
 # install Prism
-ADD https://raw.githubusercontent.com/stoplightio/prism/master/install.sh install.sh
+ADD https://raw.githubusercontent.com/stoplightio/prism/master/install install.sh
 RUN chmod +x ./install.sh && sync && \
     ./install.sh && \
     rm ./install.sh

--- a/lib/SendGrid.php
+++ b/lib/SendGrid.php
@@ -34,7 +34,7 @@ class SendGrid
      * Setup the HTTP Client
      *
      * @param string $apiKey  Your Twilio SendGrid API Key.
-     * @param array  $options An array of options, currently only "host", "curl" and
+     * @param array  $options An array of options, currently only "host", "curl", "path" and
      *                        "impersonateSubuser" are implemented.
      */
     public function __construct($apiKey, $options = array())
@@ -48,6 +48,9 @@ class SendGrid
         $host = isset($options['host']) ? $options['host'] :
             'https://api.sendgrid.com';
 
+        $path = isset($options['path']) ? $options['path'] :
+            '/v3';
+
         if (!empty($options['impersonateSubuser'])) {
             $headers[] = 'On-Behalf-Of: '. $options['impersonateSubuser'];
         }
@@ -57,7 +60,7 @@ class SendGrid
         $this->client = new \SendGrid\Client(
             $host,
             $headers,
-            '/v3',
+            $path,
             null,
             $curlOptions
         );

--- a/test/unit/SendGridTest.php
+++ b/test/unit/SendGridTest.php
@@ -85,4 +85,26 @@ class SendGridTest extends BaseTestClass
             $sg5->client->getHeaders()
         );
     }
+    
+
+    /**
+     * Test that user can override the path when instantiating a new SendGrid client
+     */
+    public function testCanOverridePath()
+    {
+        $opts['path'] = 'v4';
+
+        $sg = new \SendGrid(self::$apiKey, $opts);
+        $headers = [
+            'Authorization: Bearer ' . self::$apiKey,
+            'User-Agent: sendgrid/' . $sg->version . ';php',
+            'Accept: application/json'
+        ];
+
+        $this->assertEquals(
+            $sg->client->getHost(),
+            'https://api.sendgrid.com',
+            '/v4'
+        );
+    }
 }


### PR DESCRIPTION
…g "v3".

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [X ] I acknowledge that all my contributions will be made under the project's license
- [X ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X ] I have read the [Contribution Guide] and my PR follows them.
- [X ] I updated my branch with the development branch.
- [X ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [X ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Gives the user an option to omit or override the default "v3" path of the SendGrid Client object
- If the user chooses to not specify, then the default "v3" value will be used (as it currently is)

If you have questions, please send an email to [Twilio Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
